### PR TITLE
MOM-2115 Add data-export queue to RedisUploadQueueCollector collector

### DIFF
--- a/src/collectors/redisuploadqueue/redisuploadqueue.py
+++ b/src/collectors/redisuploadqueue/redisuploadqueue.py
@@ -52,10 +52,11 @@ class RedisUploadQueueCollector(diamond.collector.Collector):
         port = self.config['port']
 
         try:
-            queue_length = redis.StrictRedis(host=host,port=port).llen('celery')
-            self.publish('length', int(queue_length))
+            redis_ = redis.StrictRedis(host=host,port=port)
+            self.publish('length', int(redis_.llen('celery')))
+            self.publish('data-export-length', int(redis_.llen('data-export')))
         except Exception as ex:
             self.log.error("RedisUploadQueueCollector: failed to connect to %s:%i. %s.",
                            host, port, ex)
-        
+
 


### PR DESCRIPTION
We could add another type of Collector instead of having this one do
both but this prevents adding another config for it and moving both the
common parts into another class (and hopefully uses the same Redis
connection for both calls but I don't know the redis library).
